### PR TITLE
Add importing 'image/png'

### DIFF
--- a/Graphics.go
+++ b/Graphics.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/freetype/truetype"
    "golang.org/x/image/font"
    "image/color"
+   _ "image/png"
    "fmt"
    "path"
   	"io/ioutil"


### PR DESCRIPTION
Due to the recent change of Ebiten, importing "image/png" explicitly is now required. Thank you for using Ebiten!